### PR TITLE
fix: add missing links and cross-link automotive security

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ List of security lists.
   * Automotive
     * [CANbus](https://github.com/iDoka/awesome-canbus)
     * [CANb IDs](https://github.com/iDoka/awesome-automotive-can-id)
+    * [Awesome Automotive Security](https://github.com/hexsecs/awesome-automotive-security)
 * Meta
   * [awesome](https://github.com/sindresorhus/awesome)
   * [lists](https://github.com/jnv/lists)


### PR DESCRIPTION
## Summary
- Fix typos: Disassember → Disassemblers, Mulitools → Multitools
- Add missing URLs: dnSpy, de4dot, JD-GUI, JADX
- Cross-link with awesome-automotive-security