### PR TITLE
Stop accepting 403 as a live link

### DIFF
--- a/.github/workflows/markdown.links.config.json
+++ b/.github/workflows/markdown.links.config.json
@@ -16,7 +16,15 @@
     }
   ],
   "ignorePatterns": [
-    { "pattern": "^https://www\\.analog\\.com/" }
+    {
+      "pattern": "^https://www\\.analog\\.com/"
+    },
+    {
+      "pattern": "^https://www\\.nordicsemi\\.com/"
+    }
   ],
-  "aliveStatusCodes": [200, 206]
+  "aliveStatusCodes": [
+    200,
+    206
+  ]
 }

--- a/.github/workflows/markdown.links.config.json
+++ b/.github/workflows/markdown.links.config.json
@@ -1,12 +1,22 @@
 {
   "httpHeaders": [
     {
-      "urls": ["https://www.sourceware.org/","https://www.udemy.com/", "https://www.analog.com/", "https://github.com/", "https://guides.github.com/", "https://help.github.com/", "https://docs.github.com/"],
+      "urls": [
+        "https://www.sourceware.org/",
+        "https://www.udemy.com/",
+        "https://github.com/",
+        "https://guides.github.com/",
+        "https://help.github.com/",
+        "https://docs.github.com/"
+      ],
       "headers": {
         "Accept-Encoding": "zstd, br, gzip, deflate",
         "User-Agent": "Mozilla/5.0 (Windows NT 6.2; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.5112.102 Safari/537.36"
       }
     }
   ],
-  "aliveStatusCodes": [200, 206, 403]
+  "ignorePatterns": [
+    { "pattern": "^https://www\\.analog\\.com/" }
+  ],
+  "aliveStatusCodes": [200, 206]
 }


### PR DESCRIPTION
`aliveStatusCodes` listed `403`, so any link that started returning it — a repo made private, a page moved behind auth — would pass CI silently. That was a workaround for hosts with bot protection, but it was applied globally.

Replaced with an explicit `ignorePatterns` list naming the two hosts that genuinely can't be checked, so every other link is now held to a real 200.

## Which hosts actually need ignoring

Local testing was misleading here, and the first CI run on this branch corrected it:

- **`analog.com`** — fails on a connection timeout rather than a status code, from both my network and GitHub's.
- **`nordicsemi.com`** — returns 200 to `markdown-link-check` from a residential connection but **403 from GitHub Actions runners**. It reproduced on a clean re-run, so it's deterministic, not flaky.

SourceForge, the Trusted Computing Group, Codeberg and source.android.com all return 200 to `markdown-link-check` from CI and need no special handling. Adding a browser User-Agent does not help any of these hosts — they use real bot detection rather than UA sniffing.

`greatscottgadgets.com` failed once with a socket hang up and passed on a clean re-run. Left checked: one transient error against four otherwise-healthy URLs on that host isn't worth dropping the coverage.

## This also fixes a check that fails today

With `403` accepted but `analog.com` still checked, the configuration on `main` exits non-zero on the ADALM-PLUTO link — the failure is visible on #29, which doesn't touch this config at all. The monthly scheduled run would be hitting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)