### PR TITLE
Add binary diffing, decompilers, and extraction tools

### DIFF
--- a/.github/workflows/markdown.links.config.json
+++ b/.github/workflows/markdown.links.config.json
@@ -31,6 +31,7 @@
   ],
   "aliveStatusCodes": [
     200,
+    202,
     206
   ]
 }

--- a/README.md
+++ b/README.md
@@ -64,7 +64,11 @@ Topics covered include firmware extraction and fuzzing, secure boot and root of 
 * [Kaitai Struct](https://kaitai.io/) - Declarative language used to describe various binary data structures, laid out in files or in memory: i.e. binary file formats, network stream packet formats, etc.
 * [LIEF](https://github.com/lief-project/LIEF) - Library to Instrument Executable Formats: parse, modify, and abstract ELF, PE, Mach-O, DEX, and OAT binaries found in firmware images.
 * [OFRAK](https://github.com/redballoonsecurity/ofrak) - Binary analysis and modification platform that combines the ability to unpack, analyze, modify, and repack binaries.
+* [Patcherex2](https://github.com/purseclab/Patcherex2) - Static binary patching framework for x86, ARM, MIPS, and PowerPC, supporting instruction insertion and function replacement in extracted firmware.
+* [sasquatch](https://github.com/devttys0/sasquatch) - Patched unsquashfs that handles the vendor-modified SquashFS variants common in consumer router firmware; used internally by Binwalk and unblob.
 * [SCOUT](https://github.com/R00T-Kim/SCOUT) - Deterministic firmware analysis pipeline emitting SARIF 2.1, CycloneDX 1.6 + VEX SBOM, and hash-anchored evidence chains; auto-detects Ghidra and runs P-code SSA dataflow taint with 4-tier confidence caps. Pure stdlib (no pip dependencies).
+* [ubi_reader](https://github.com/onekey-sec/ubi_reader) - Extracts UBI and UBIFS images, the raw-NAND filesystem format that generic carvers handle poorly.
+* [UEFITool](https://github.com/LongSoft/UEFITool) - Viewer and editor for UEFI firmware images, able to parse the volume structure and extract or replace individual modules.
 * [unblob](https://github.com/onekey-sec/unblob) - Fast, accurate firmware extraction engine from ONEKEY supporting 100+ archive, compression, and filesystem formats with fewer false positives than Binwalk. Presented at DEF CON 30.
 * [VulHunt](https://github.com/vulhunt-re/vulhunt) - Lua-rule-based vulnerability detection framework from Binarly's research team that operates across disassembly, IR, and decompiled code simultaneously, with dedicated UEFI module scanning support.
 
@@ -74,14 +78,20 @@ Topics covered include firmware extraction and fuzzing, secure boot and root of 
 * [Angr Management](https://github.com/angr/angr-management) - Multi-architecture binary analysis toolkit, with the capability to perform dynamic symbolic execution (like Mayhem, KLEE, etc.) and various static analyses on binaries. If you'd like to learn how to use it, you're in the right place!
 * [BARF](https://github.com/programa-stic/barf-project) - A binary analysis and reverse engineering framework with support for ROP gadget search and CFG recovery.
 * [Binary Ninja](https://binary.ninja/) 💰 - Interactive disassembler, decompiler, and binary analysis platform for reverse engineers, malware analysts, vulnerability researchers, and software developers that runs on Windows, macOS, and Linux.
+* [BinDiff](https://github.com/google/bindiff) - Google's binary diffing engine for comparing two versions of a binary, matching functions across them to locate patched vulnerabilities and port symbols.
 * [Capstone](https://github.com/capstone-engine/capstone) - Lightweight multi-platform, multi-architecture disassembly framework. Their target is to make Capstone the ultimate disassembly engine for binary analysis and reversing in the security community.
 * [Cutter](https://cutter.re/) - Free and Open Source RE Platform powered by Rizini.
+* [dewolf](https://github.com/fkie-cad/dewolf) - Decompiler from Fraunhofer FKIE focused on readable output, built as a Binary Ninja plugin over its medium-level IL.
 * [Ghidra](https://ghidra-sre.org/) - A software reverse engineering (SRE) suite of tools developed by NSA's Research Directorate in support of the Cybersecurity mission.
+* [Ghidriff](https://github.com/clearbluejar/ghidriff) - Headless Ghidra patch diffing that runs from the command line and emits Markdown or JSON, making binary diffs practical to automate in CI.
 * [IDA Pro](https://hex-rays.com/ida-pro/) 💰 - Disassembler capable of creating maps of their execution to show the binary instructions that are actually executed by the processor in a symbolic representation (assembly language). Advanced techniques have been implemented into IDA Pro so that it can generate assembly language source code from machine-executable code and make this complex code more human-readable.
 * [Keystone](https://github.com/keystone-engine/keystone) - A lightweight multi-architecture assembler framework that complements Capstone.
+* [Miasm](https://github.com/cea-sec/miasm) - Reverse engineering framework with its own intermediate language, a JIT emulator, and symbolic execution, covering MSP430 and MIPS alongside the usual architectures.
 * [radare2](https://www.radare.org/n/) - A free/libre toolchain for easing several low level tasks like forensics, software reverse engineering, exploiting, debugging. It is composed by a bunch of libraries (which are extended with plugins) and programs that can be automated with almost any programming language.
+* [Reko](https://github.com/uxmal/reko) - Open-source decompiler with unusually broad architecture coverage, useful for embedded cores that mainstream tools support poorly.
 * [RetDec](https://github.com/avast/retdec) - Retargetable machine-code decompiler from Avast supporting ARM, MIPS, x86, and other architectures common in embedded firmware.
 * [Rizin](https://rizin.re/) - A free and open-source Reverse Engineering framework, providing a complete binary analysis experience with features like Disassembler, Hexadecimal editor, Emulation, Binary inspection, Debugger, and more.
+* [Triton](https://github.com/JonathanSalwan/Triton) - Dynamic binary analysis library providing symbolic execution, taint tracking, and an SMT solver interface for x86, ARM, AArch64, and RISC-V.
 * [Vivisect](https://github.com/vivisect/vivisect) - A combined disassembler/static analysis/symbolic execution/debugger framework.
 
 ### Debugging Tools


### PR DESCRIPTION
Third content PR from the audit. Entry count goes from 219 to 229.

Contains one unrelated CI fix in its own commit — see the second half.

## Disassemblers/Decompilers — +6

**BinDiff** fills the most conspicuous hole: the list had **no binary diffing at all**, despite patch diffing being a core firmware vulnerability workflow. **Ghidriff** covers the same ground headless and emits Markdown or JSON, so diffs can run in CI.

**Triton** and **Miasm** add symbolic execution and taint alongside angr — Miasm notable here for MSP430 and MIPS. **Reko** and **dewolf** add decompilers that between them cover embedded cores the mainstream tools handle poorly.

## Binary Parsing and Analysis Tools — +4

**ubi_reader** (UBI/UBIFS images), **sasquatch** (vendor-modified SquashFS common in consumer router firmware), and **Patcherex2** — the list had plenty of ways to *find* a firmware bug and none to modify the binary afterwards. **UEFITool** goes here rather than in a section of its own, since one entry doesn't justify a heading.

**LLM4Decompile was considered and left out.** Popular, but a research prototype rather than something to reach for on real firmware.

## The alphabetical check earned its keep immediately

On its first outing, #33 caught two orderings I got wrong in this PR: `BinDiff` sorts *after* `Binary Ninja`, and `Ghidriff` *after* `Ghidra`. Both differ only at the fourth character, and both would have sailed through review.

---

## Unrelated: treat HTTP 202 as a live link

Separate commit (`df3afaf`). Two hosts have started answering the checker with 202 rather than 200 — `eur-lex.europa.eu` consistently, `sdrangel.org` intermittently. The latter is what turned `main` red after #33. Neither is broken in a browser; 202 is being used as an anti-bot response, and it isn't confined to one host, so adding each to `ignorePatterns` as it appears wouldn't converge.

**This isn't a reversal of #30**, which removed `403` from this same list. 403 is an explicit *refusal* and is exactly what a genuinely broken link looks like — a repo made private, a page moved behind auth — so accepting it globally hid real failures. 202 is in the **2xx family** and means the request was accepted. Treating it as alive keeps the check honest about refusals while tolerating servers that answer this way.

**The cost, stated plainly:** `eur-lex.europa.eu` returns 202 for a *nonexistent* CELEX number as well as a real one, so the two UNECE links added in #34 are now only weakly verified. They were confirmed by fetching each document and matching its title at the time they were added, when the host still answered 200.

This also means the checkability argument I used in #34 to prefer EUR-Lex over `unece.org` no longer holds. EUR-Lex is still the better source — official EU law text, stable URLs — but on source quality rather than verifiability.

## Verification

- `npm run validate` → 0 markdownlint issues, awesome-lint clean, 229 entries, alphabetized, anchors resolve.
- `npm run lint:links` → passes on the first attempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)